### PR TITLE
IIQDA fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 *.bak
 checkout
+**/.classpath
+**/.project
+**/*.prefs

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CorePlugin.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CorePlugin.java
@@ -78,6 +78,10 @@ public class CorePlugin extends AbstractUIPlugin {
   public static void logTrace(String msg) {
     log(Status.INFO, msg, null);
   }
+  
+  public static void logWarning(String msg) {
+	log(Status.WARNING, msg, null);
+  }
 
   public static void logError(String msg) {
     log(Status.ERROR, msg, null);

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
@@ -57,6 +57,7 @@ import org.w3c.dom.DocumentType;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.w3c.dom.Text;
+import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
@@ -64,15 +65,30 @@ import sailpoint.iiqda.exceptions.ConnectionException;
 import sailpoint.iiqda.exceptions.DetailedConnectionException;
 
 public class CoreUtils {
+	
+	/**
+	 * The class that reads entity data from the sailpoint.dtd stored in the
+	 * project, if one exists. This allows Java 9+ to properly format the XML
+	 * files on import.
+	 */
+	public static class DTDEntityResolver implements EntityResolver {
+		@Override
+		public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
+			if ((publicId.equals("sailpoint.dtd") || systemId.equals("file:///Applications/Eclipse.app/Contents/MacOS/sailpoint.dtd")) && CoreUtils.getSailpointDTD() != null) {
+				try {
+					InputSource is = new InputSource(CoreUtils.getSailpointDTD().getContents());
+					is.setPublicId("sailpoint.dtd");
+					is.setSystemId("sailpoint.dtd");
+					return is;
+				}
+				catch (Exception e) {
+					throw new IOException(e);
+				}
+			}
+			return new InputSource(new StringReader(""));
+		}
+	}
 
-  private static final boolean DEBUG_UTILS = "true".equalsIgnoreCase(Platform
-      .getDebugOption(CorePlugin.PLUGIN_ID+"/debug/CoreUtils"));
-
-  // The plug-in ID
-  public static final String PLUGIN_ID = "sailpoint.IIQ_Deployment_Accelerator"; //$NON-NLS-1$
-
-  private static ImageRegistry imageRegistry;
-  
   public enum Preference {
     USE_SSB_TEMPLATE("Use_SSB_Template");
 
@@ -87,27 +103,43 @@ public class CoreUtils {
     }
 
   }
+
+  private static final boolean DEBUG_UTILS = "true".equalsIgnoreCase(Platform
+      .getDebugOption(CorePlugin.PLUGIN_ID+"/debug/CoreUtils"));
   
-  public ImageRegistry getImageRegistry() {
-    if (imageRegistry == null) {
-      imageRegistry = createImageRegistry();
+  private static ImageRegistry imageRegistry;
+
+  // The plug-in ID
+  public static final String PLUGIN_ID = "sailpoint.IIQ_Deployment_Accelerator"; //$NON-NLS-1$
+  
+  /**
+   * The Sailpoint DTD file, populated on first call to doReverseSubstitution()
+   */
+  public static IFile SAILPOINT_DTD = null;
+  
+  public static String camelCase(String name) {
+
+    if(name==null) return null;
+
+    StringBuffer camel=new StringBuffer();
+    boolean upper=false;
+    for(int i=0;i<name.length();i++) {
+      char c=name.charAt(i);
+      if(c==' ') upper=true;
+      else {
+        if(upper) {
+          camel.append(Character.toUpperCase(c));
+          upper=false;
+        } else {
+          camel.append(Character.toLowerCase(c));
+        }
+      }
     }
-    return imageRegistry;
+    return camel.toString();
   }
-
-  protected ImageRegistry createImageRegistry() { 
-    //If we are in the UI Thread use that
-    if(Display.getCurrent() != null) {
-      return new ImageRegistry(Display.getCurrent());
-    }
-
-    if(PlatformUI.isWorkbenchRunning()) {
-      return new ImageRegistry(PlatformUI.getWorkbench().getDisplay());
-    }
-
-    //Invalid thread access if it is not the UI Thread 
-    //and the workbench is not created.
-    throw new SWTError(SWT.ERROR_THREAD_INVALID_ACCESS);
+  
+  public static String capitalize(String str) {
+    return str.substring(0,1).toUpperCase()+str.substring(1);
   }
 
   public static InputStream docAsStream(Document doc) throws CoreException {
@@ -143,11 +175,56 @@ public class CoreUtils {
   
   }
 
+  public static Reader documentAsStream(Document doc, boolean shouldCDATASource) {
+    DOMSource domSource = new DOMSource(doc);
+    StringWriter writer = new StringWriter();
+    StreamResult result = new StreamResult(writer);
+    TransformerFactory tf = TransformerFactory.newInstance();
+    try {
+      Transformer transformer = tf.newTransformer();
+      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+      DocumentType doctype = doc.getDoctype();
+      if(doctype != null) {
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
+        transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
+      }
+      if(shouldCDATASource) {
+        transformer.setOutputProperty(OutputKeys.CDATA_SECTION_ELEMENTS, "Source");
+      }
+      // TODO: Should be able to do this here:
+      // transformer.setOutputProperty("{http://xml.apache.org/xalan}line-separator","\n");
+      // but it doesn't work. Come back and look into this when we run out of real problems
+      System.setProperty("line.separator", "\n");
+      transformer.transform(domSource, result);
+      
+      // In Java 9+, these tags are formatted with strange spaces before and after
+      String xml = writer.toString();
+      xml = xml.replaceAll("(?s)<Source>.+?<!\\[CDATA", "<Source><![CDATA");
+      xml = xml.replaceAll("(?s)]]>.+?</Source>", "]]></Source>");
+      return new StringReader(xml);
+    } catch (TransformerConfigurationException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    } catch (IllegalArgumentException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    } catch (TransformerException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    return null;
+  
+  }
+
   /**
    * @since 2.1
    */
   public static Reader doReverseSubstitution(Reader stream, IProject project) throws CoreException, IOException {
     IFile f=project.getFile("reverse"+IIQDAConstants.TARGET_SUFFIX);
+    IFile dtd = project.getFile("sailpoint.dtd");
+    if (dtd.exists()) {
+        SAILPOINT_DTD = dtd;
+    }
     Properties props=new Properties();
     if(f.exists()) {
       props.load(f.getContents());
@@ -160,11 +237,14 @@ public class CoreUtils {
     try {
       XPathFactory xPathfactory = XPathFactory.newInstance();
       DocumentBuilderFactory dbfact = DocumentBuilderFactory.newInstance();
-      // Don't validate against the DTD here.. That can be done as part of the builder
-      // Besides, if we're importing from IdentityIQ, it won't go into Hibernate unless
-      // it's valid according to the DTD..
-      dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd",false);
+      // We need to validate against the DTD here, because this is how Java 9+
+      // knows to format whitespace appropriately.
+      dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
+      dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", true);
+      
       DocumentBuilder builder = dbfact.newDocumentBuilder();
+      builder.setEntityResolver(new DTDEntityResolver());
+      
       Document indexname_input = builder.parse(new InputSource(stream));
       indexname_input.setXmlStandalone(true);
   
@@ -222,6 +302,42 @@ public class CoreUtils {
   
   }
 
+  public static MessageConsole findConsole(String name) {
+    ConsolePlugin plugin = ConsolePlugin.getDefault();
+    IConsoleManager conMan = plugin.getConsoleManager();
+    IConsole[] existing = conMan.getConsoles();
+    for (int i = 0; i < existing.length; i++)
+      if (name.equals(existing[i].getName()))
+        return (MessageConsole) existing[i];
+    //no console found, so create a new one
+    MessageConsole myConsole = new MessageConsole(name, null);
+    conMan.addConsoles(new IConsole[]{myConsole});
+    return myConsole;
+  }
+
+  public static IFile getActiveWorkbenchFile() {
+    // There seems to be no other way to get the active editor (and by extension
+    // the IPath
+    IWorkbench workbench = PlatformUI.getWorkbench();
+    IWorkbenchWindow window = 
+        workbench == null ? null : workbench.getActiveWorkbenchWindow();
+    IWorkbenchPage activePage = 
+        window == null ? null : window.getActivePage();
+
+    IEditorPart editor = 
+        activePage == null ? null : activePage.getActiveEditor();
+    IEditorInput input = 
+        editor == null ? null : editor.getEditorInput();
+    IFile file = input instanceof FileEditorInput 
+        ? ((FileEditorInput)input).getFile()
+            : null;
+        return file;        
+  }
+
+  public static IFile getSailpointDTD() {
+      return SAILPOINT_DTD;
+  }
+
   public static String join(Collection<String> c, String delimiter) {
     if (null == c)
       return null;
@@ -235,78 +351,6 @@ public class CoreUtils {
     }
     return buf.toString();
   
-  }
-
-  public static Reader stringDocumentAsStream(String obj, boolean shouldCDATASource) {
-    DocumentBuilderFactory dbfact = DocumentBuilderFactory.newInstance();
-    // Don't validate against the DTD here.. That can be done as part of the builder
-    // Besides, if we're importing from IdentityIQ, it won't go into Hibernate unless
-    // it's valid according to the DTD..
-    dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd",false);
-    try {
-      DocumentBuilder builder = dbfact.newDocumentBuilder();
-      Document doc = builder.parse(new InputSource(new StringReader(obj)));
-      return documentAsStream(doc, shouldCDATASource);
-    } catch (SAXException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (IOException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (ParserConfigurationException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-    return null;
-  }
-
-  public static Reader documentAsStream(Document doc, boolean shouldCDATASource) {
-    DOMSource domSource = new DOMSource(doc);
-    StringWriter writer = new StringWriter();
-    StreamResult result = new StreamResult(writer);
-    TransformerFactory tf = TransformerFactory.newInstance();
-    try {
-      Transformer transformer = tf.newTransformer();
-      transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-      DocumentType doctype = doc.getDoctype();
-      if(doctype != null) {
-        transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, doctype.getPublicId());
-        transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
-      }
-      if(shouldCDATASource) {
-        transformer.setOutputProperty(OutputKeys.CDATA_SECTION_ELEMENTS, "Source");
-      }
-      // TODO: Should be able to do this here:
-      // transformer.setOutputProperty("{http://xml.apache.org/xalan}line-separator","\n");
-      // but it doesn't work. Come back and look into this when we run out of real problems
-      System.setProperty("line.separator", "\n");
-      transformer.transform(domSource, result);
-      return new StringReader(writer.toString());
-    } catch (TransformerConfigurationException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (IllegalArgumentException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    } catch (TransformerException e) {
-      // TODO Auto-generated catch block
-      e.printStackTrace();
-    }
-    return null;
-  
-  }
-
-  public static MessageConsole findConsole(String name) {
-    ConsolePlugin plugin = ConsolePlugin.getDefault();
-    IConsoleManager conMan = plugin.getConsoleManager();
-    IConsole[] existing = conMan.getConsoles();
-    for (int i = 0; i < existing.length; i++)
-      if (name.equals(existing[i].getName()))
-        return (MessageConsole) existing[i];
-    //no console found, so create a new one
-    MessageConsole myConsole = new MessageConsole(name, null);
-    conMan.addConsoles(new IConsole[]{myConsole});
-    return myConsole;
   }
 
   public static StringBuilder readFile(IFile file) throws CoreException{
@@ -332,78 +376,6 @@ public class CoreUtils {
     return buf;
   }
 
-  public static IFile getActiveWorkbenchFile() {
-    // There seems to be no other way to get the active editor (and by extension
-    // the IPath
-    IWorkbench workbench = PlatformUI.getWorkbench();
-    IWorkbenchWindow window = 
-        workbench == null ? null : workbench.getActiveWorkbenchWindow();
-    IWorkbenchPage activePage = 
-        window == null ? null : window.getActivePage();
-
-    IEditorPart editor = 
-        activePage == null ? null : activePage.getActiveEditor();
-    IEditorInput input = 
-        editor == null ? null : editor.getEditorInput();
-    IFile file = input instanceof FileEditorInput 
-        ? ((FileEditorInput)input).getFile()
-            : null;
-        return file;        
-  }
-
-  public static IStatus toErrorStatus(String message) {
-    IStatus stat=new Status(
-        IStatus.ERROR,
-        "IIQ Plugin",
-        message);
-    return stat;
-  }
-
-  public static IStatus toWarningStatus(String message) {
-    IStatus stat=new Status(
-        IStatus.WARNING,
-        "IIQ Plugin",
-        message);
-    return stat;
-  }
-
-  public static void throwCE(String msg) throws CoreException{
-    IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, 
-        msg, null);
-    throw new CoreException(status);
-
-  }
-
-  public static void throwAsCE(String msg, Throwable t) throws CoreException{
-    IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, 
-        msg, t);
-    throw new CoreException(status);
-
-  }
-
-  public static String toCamelCase(String name) {
-    return toCamelCase(name, false);
-  }
-  public static String toCamelCase(String name, boolean isUpper) {
-    if(name==null) return null;
-
-    StringBuilder camel=new StringBuilder();
-    boolean upper=isUpper;
-    for(int i=0;i<name.length();i++) {
-      char c=name.charAt(i);
-      if(c==' ') upper=true;
-      else {
-        if(upper) {
-          camel.append(Character.toUpperCase(c));
-          upper=false;
-        } else {
-          camel.append(Character.toLowerCase(c));
-        }
-      }
-    }
-    return camel.toString();
-  }
-
   public static void showConnectionError(Shell shell, ConnectionException e) {
     IStatus errors=null;      
     if (e instanceof DetailedConnectionException) {
@@ -424,12 +396,52 @@ public class CoreUtils {
     return;
   }
 
-  public static String camelCase(String name) {
+  public static Reader stringDocumentAsStream(String obj, boolean shouldCDATASource) {
+    DocumentBuilderFactory dbfact = DocumentBuilderFactory.newInstance();
+    // Don't validate against the DTD here.. That can be done as part of the builder
+    // Besides, if we're importing from IdentityIQ, it won't go into Hibernate unless
+    // it's valid according to the DTD..
+    dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd",false);
+    try {
+      DocumentBuilder builder = dbfact.newDocumentBuilder();
+      Document doc = builder.parse(new InputSource(new StringReader(obj)));
+      return documentAsStream(doc, shouldCDATASource);
+    } catch (SAXException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    } catch (IOException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    } catch (ParserConfigurationException e) {
+      // TODO Auto-generated catch block
+      e.printStackTrace();
+    }
+    return null;
+  }
 
+  public static void throwAsCE(String msg, Throwable t) throws CoreException{
+    IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, 
+        msg, t);
+    throw new CoreException(status);
+
+  }
+
+  public static void throwCE(String msg) throws CoreException{
+    IStatus status = new Status(IStatus.ERROR, PLUGIN_ID, IStatus.OK, 
+        msg, null);
+    throw new CoreException(status);
+
+  }
+
+  public static String toCamelCase(String name) {
+    return toCamelCase(name, false);
+  }
+
+  public static String toCamelCase(String name, boolean isUpper) {
     if(name==null) return null;
 
-    StringBuffer camel=new StringBuffer();
-    boolean upper=false;
+    StringBuilder camel=new StringBuilder();
+    boolean upper=isUpper;
     for(int i=0;i<name.length();i++) {
       char c=name.charAt(i);
       if(c==' ') upper=true;
@@ -444,9 +456,42 @@ public class CoreUtils {
     }
     return camel.toString();
   }
+  public static IStatus toErrorStatus(String message) {
+    IStatus stat=new Status(
+        IStatus.ERROR,
+        "IIQ Plugin",
+        message);
+    return stat;
+  }
 
-  public static String capitalize(String str) {
-    return str.substring(0,1).toUpperCase()+str.substring(1);
+  public static IStatus toWarningStatus(String message) {
+    IStatus stat=new Status(
+        IStatus.WARNING,
+        "IIQ Plugin",
+        message);
+    return stat;
+  }
+
+  protected ImageRegistry createImageRegistry() { 
+    //If we are in the UI Thread use that
+    if(Display.getCurrent() != null) {
+      return new ImageRegistry(Display.getCurrent());
+    }
+
+    if(PlatformUI.isWorkbenchRunning()) {
+      return new ImageRegistry(PlatformUI.getWorkbench().getDisplay());
+    }
+
+    //Invalid thread access if it is not the UI Thread 
+    //and the workbench is not created.
+    throw new SWTError(SWT.ERROR_THREAD_INVALID_ACCESS);
+  }
+
+  public ImageRegistry getImageRegistry() {
+    if (imageRegistry == null) {
+      imageRegistry = createImageRegistry();
+    }
+    return imageRegistry;
   }
 
 

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
@@ -241,7 +241,8 @@ public class CoreUtils {
       // knows to format whitespace appropriately.
       dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
       dbfact.setAttribute("http://apache.org/xml/features/nonvalidating/load-dtd-grammar", true);
-      
+      dbfact.setIgnoringElementContentWhitespace(true);
+
       DocumentBuilder builder = dbfact.newDocumentBuilder();
       builder.setEntityResolver(new DTDEntityResolver());
       

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/CoreUtils.java
@@ -189,7 +189,7 @@ public class CoreUtils {
         transformer.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, doctype.getSystemId());
       }
       if(shouldCDATASource) {
-        transformer.setOutputProperty(OutputKeys.CDATA_SECTION_ELEMENTS, "Source");
+        transformer.setOutputProperty(OutputKeys.CDATA_SECTION_ELEMENTS, "Source Body FilterString");
       }
       // TODO: Should be able to do this here:
       // transformer.setOutputProperty("{http://xml.apache.org/xalan}line-separator","\n");
@@ -290,7 +290,7 @@ public class CoreUtils {
           }
         }
       }
-      return documentAsStream(indexname_input, false);
+      return documentAsStream(indexname_input, true);
     } catch (XPathExpressionException | ParserConfigurationException e) {
       IStatus status=toErrorStatus("XPathExpressionException "+e);
       throw new CoreException(status);

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/IIQDAConstants.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/core/IIQDAConstants.java
@@ -16,6 +16,8 @@ public class IIQDAConstants {
   // The plug-in ID
   public static final String PLUGIN_ID = "sailpoint.IIQ_Deployment_Accelerator"; //$NON-NLS-1$
 	
+  public static final String SECRET_SUFFIX = ".secret.properties";
+  
   public static final String TARGET_SUFFIX = ".target.properties";
 
 

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/deployer/RESTClient.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/deployer/RESTClient.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -173,8 +174,9 @@ public class RESTClient {
 
     //    X509HostnameVerifier hostnameVerifier = new AllowAllHostnameVerifier();
     RequestConfig config = RequestConfig.custom()
-        .setSocketTimeout(timeout)
-        .setConnectTimeout(timeout)
+        .setSocketTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
+        .setConnectTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
+        .setConnectionRequestTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
         .setCircularRedirectsAllowed(true)
         .build();
 

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/deployer/RESTClient.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.core/src/sailpoint/iiqda/deployer/RESTClient.java
@@ -171,12 +171,16 @@ public class RESTClient {
         f.close();
       } catch (Exception e) {}
     }
+    
+    if (timeout < 1000) {
+    	CorePlugin.logWarning("Timeout of " + timeout + " appears to be specified in seconds, but IIQDA needs milliseconds");
+    }
 
     //    X509HostnameVerifier hostnameVerifier = new AllowAllHostnameVerifier();
     RequestConfig config = RequestConfig.custom()
-        .setSocketTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
-        .setConnectTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
-        .setConnectionRequestTimeout((int) TimeUnit.MILLISECONDS.convert(timeout, TimeUnit.SECONDS))
+        .setSocketTimeout(timeout)
+        .setConnectTimeout(timeout)
+        .setConnectionRequestTimeout(timeout)
         .setCircularRedirectsAllowed(true)
         .build();
 

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/ArtifactHelper.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/ArtifactHelper.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.io.input.ReaderInputStream;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 
@@ -34,9 +35,14 @@ public class ArtifactHelper {
   
   public static void writeObject(IIQRESTClient client, IFile file, String type, String name, 
       boolean shouldInsertCDATA, IProgressMonitor monitor) throws ConnectionException, CoreException, IOException {
+    IFile dtd;
     String obj=client.getObject(type, name);
     Reader stream = null;
-
+    IProject project = file.getProject();
+    if (project != null && (dtd = project.getFile("sailpoint.dtd")).exists()) {
+        CoreUtils.SAILPOINT_DTD = dtd;
+    }
+    
     stream=CoreUtils.stringDocumentAsStream(ArtifactHelper.clean(obj), shouldInsertCDATA);
     Reader  revStream=CoreUtils.doReverseSubstitution(stream, file.getProject());
     if (file.exists()) {

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/deployer/IIQRESTClient.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/deployer/IIQRESTClient.java
@@ -2,6 +2,7 @@ package sailpoint.iiqda.deployer;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -41,9 +42,21 @@ public class IIQRESTClient extends RESTClient {
   public IIQRESTClient(IProject project, String environment) throws CoreException {
     try {
       this.fProject=project;
-      IFile f=project.getFile(environment+IIQDAConstants.TARGET_SUFFIX);
       Properties props=new Properties();
-      props.load(f.getContents());
+      
+      IFile secretProps = project.getFile(environment+IIQDAConstants.SECRET_SUFFIX);
+      if (secretProps.exists()) {
+    	  try (InputStream contents = secretProps.getContents()) {
+    		  props.load(contents);
+    	  }
+      }
+      
+      if (!props.containsKey(IIQPreferenceConstants.P_URL)) {
+          IFile targetProps = project.getFile(environment+IIQDAConstants.TARGET_SUFFIX);
+          try (InputStream contents = targetProps.getContents()) {
+        	  props.load(contents);
+          }
+      }
 
       // Get connection details
       String iUrl = (String)props.get(IIQPreferenceConstants.P_URL);

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/validation/BaseXMLArtifactParser.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/validation/BaseXMLArtifactParser.java
@@ -15,6 +15,7 @@ import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import com.ctc.wstx.osgi.InputFactoryProviderImpl;
 import org.codehaus.stax2.XMLInputFactory2;
 import org.codehaus.stax2.XMLStreamReader2;
 import org.eclipse.core.resources.IFolder;
@@ -101,7 +102,7 @@ public abstract class BaseXMLArtifactParser {
     VALIDATIONSCRIPT("ValidationScript"),
     VALIDATORSCRIPT("ValidatorScript"),
     VARIABLE("Variable"),
-    VALUE("value"),
+    VALUE("Value"),
     VALUESCRIPT("ValueScript"),
     WORKFLOW("Workflow"),
     NONE("none");
@@ -192,10 +193,10 @@ public abstract class BaseXMLArtifactParser {
   }
 
   public void parse(boolean endAtRoot) throws XMLArtifactParserException {
-
     artifacts = new ArrayList<IArtifactRootElement>();
-
-    XMLInputFactory2 fac = (XMLInputFactory2)XMLInputFactory2.newInstance();
+    
+    InputFactoryProviderImpl iprovider = new InputFactoryProviderImpl();
+    XMLInputFactory2 fac = iprovider.createInputFactory();
     XMLStreamReader2 stream = null;
     fac.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
     fac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES,

--- a/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/validation/SimpleArtifactParser.java
+++ b/bundles/sailpoint.IIQ_Deployment_Accelerator.identityiq/src/sailpoint/iiqda/validation/SimpleArtifactParser.java
@@ -16,6 +16,8 @@ import org.codehaus.stax2.DTDInfo;
 import org.codehaus.stax2.XMLInputFactory2;
 import org.codehaus.stax2.XMLStreamReader2;
 
+import com.ctc.wstx.osgi.InputFactoryProviderImpl;
+
 import sailpoint.iiqda.IIQPlugin;
 import sailpoint.iiqda.exceptions.XMLArtifactParserException;
 
@@ -61,8 +63,9 @@ public class SimpleArtifactParser {
   }
   
   public void parse(boolean stopAtFirstArtifact) throws XMLArtifactParserException {
-    XMLInputFactory2 fac = (XMLInputFactory2)XMLInputFactory2.newInstance();
-    XMLStreamReader2 stream = null;
+	InputFactoryProviderImpl iprovider = new InputFactoryProviderImpl();
+	XMLInputFactory2 fac = iprovider.createInputFactory();
+	XMLStreamReader2 stream = null;
     fac.setProperty(XMLInputFactory.IS_VALIDATING, Boolean.FALSE);
     fac.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
     fac.setProperty(XMLInputFactory.SUPPORT_DTD, Boolean.FALSE);

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,10 @@
 
   <properties>
     <tycho.version>1.3.0</tycho.version>
+    <eclipse.version.name>photon</eclipse.version.name>
+    <eclipse.version.number>4.8</eclipse.version.number>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <kevtest>Something</kevtest>
   </properties>
 
@@ -33,34 +37,6 @@
         <extensions>true</extensions>
       </plugin>
     </plugins>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.itemis.maven.plugins</groupId>
-          <artifactId>unleash-maven-plugin</artifactId>
-          <version>2.9.3</version>
-          <dependencies>
-            <dependency>
-              <groupId>com.itemis.maven.plugins</groupId>
-              <artifactId>unleash-scm-provider-git</artifactId>
-              <version>2.2.0</version>
-            </dependency>
-            <!-- dependency>
-              <groupId>sailpoint.kjames</groupId>
-              <artifactId>p2composite-cdi-step</artifactId>
-              <version>1.4</version>
-            </dependency-->
-            <dependency>
-              <groupId>com.itemis.maven.plugins</groupId>
-              <artifactId>cdi-plugin-hooks</artifactId>
-              <version>0.1.1</version>
-            </dependency>
-          </dependencies>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-
   </build>
 
   <repositories>
@@ -68,12 +44,12 @@
     <repository>
       <id>neon</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/neon</url>
+      <url>http://download.eclipse.org/releases/${eclipse.version.name}</url>
     </repository>
     <repository>
       <id>neon-updates</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/eclipse/updates/4.6</url>
+      <url>http://download.eclipse.org/eclipse/updates/${eclipse.version.number}</url>
     </repository>
     <repository>
       <id>swtbot</id>

--- a/releng/sailpoint.IIQ_Deployment_Accelerator.update/pom.xml
+++ b/releng/sailpoint.IIQ_Deployment_Accelerator.update/pom.xml
@@ -113,46 +113,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Update compositeContent.xml and compositeArtifacts -->
-      <plugin>
-        <groupId>sailpoint.kjames</groupId>
-        <artifactId>p2composite-maven-plugin</artifactId>
-        <version>1.2.2</version>
-        <executions>
-          <execution>
-            <id>make p2composite</id>
-            <phase>install</phase>
-            <goals>
-              <goal>p2composite</goal>
-            </goals>
-            <configuration>
-              <folder>${project.build.directory}/checkout/beta</folder>
-              <repositoryName>IdentityIQ Deployment Accelerator (Beta)</repositoryName>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <!-- Update description with point-release notes -->
-      <plugin>
-        <groupId>sailpoint.kjames</groupId>
-        <artifactId>xmlinjector-maven-plugin</artifactId>
-        <version>1.3</version>
-        <executions>
-          <execution>
-            <id>update description</id>
-            <phase>install</phase>
-            <goals>
-              <goal>xmlinject</goal>
-            </goals>
-            <configuration>
-              <targetJar>${project.build.directory}/checkout/beta/${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-${buildQualifier}/features/sailpoint.IIQ_Deployment_Accelerator.feature_${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}.${buildQualifier}.jar</targetJar>
-              <targetFile>/feature.xml</targetFile>
-              <xpath>/feature/description</xpath>
-              <contentFile>${project.basedir}/point-release-notes.txt</contentFile>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The following fixes are included here:

- Fix a very annoying pop-up ClassCastException when objects like Custom contain Source tags (one per tag!)
- Fix Java 9 XML export (specifically, spaces)
- Log a warning if the REST API timeout appears to be in seconds, not milliseconds
- Support an `ENV.secret.properties`, which can be excluded from source control, so that you don't have to check your IIQ admin passwords into Git
- Project cleanup